### PR TITLE
[RFR][BC-Break] Use AES-256 with Initialization Vector (IV)

### DIFF
--- a/cli/src/commands/init.js
+++ b/cli/src/commands/init.js
@@ -17,18 +17,16 @@ ${bold('OPTIONS')}
         --name=<name>      The configuration name (defaults to the current directory name)
         --env=<env>        The first environment to create (defaults to 'development')
         --origin=<origin>  URL of the comfy server (defaults to https://comfy.marmelab.com)
-        -p, --passphrase   Do not generate passphrase, ask for custom passphrase instead (defaults to false)
         -g, --nogitignore  Do not add .comfy directory to .gitignore
         -h, --help         Show this very help message
 
 ${bold('EXAMPLES')}
         ${cyan('comfy init')}
-        ${cyan(`comfy init --name foo --env 'development' --origin 'http://mycomfy.mydomain.com'`)}
+        ${cyan("comfy init --name foo --env 'development' --origin 'http://mycomfy.mydomain.com'")}
 `);
 };
 
 module.exports = (ui, modules) => function* (rawOptions) {
-    const ask = ui.input.text;
     const { bold, dim, yellow, green } = ui.colors;
     const options = minimist(rawOptions);
 
@@ -54,14 +52,12 @@ module.exports = (ui, modules) => function* (rawOptions) {
     const defaultProjectName = folders[folders.length - 1];
     const projectName = options.name || defaultProjectName;
     const environment = options.env || process.env.NODE_ENV || 'development';
-    const passphrase = (options.passphrase || options.p)
-        ? yield ask('- What is the encryption passphrase?')
-        : crypto.randomBytes(256).toString('hex');
+    const privateKey = modules.project.generateNewPrivateKey();
 
     ui.print('\nInitializing project configuration...');
 
     const project = yield modules.project.create(projectName, environment, options.origin);
-    yield modules.project.saveToConfig(project, passphrase, options.origin);
+    yield modules.project.saveToConfig(project, privateKey, options.origin);
     const { origin } = yield modules.project.retrieveFromConfig();
     if (isGitDirectory && !options.g) {
         fs.appendFileSync(gitignore, `${CONFIG_PATH}\n`);

--- a/cli/src/crypto.js
+++ b/cli/src/crypto.js
@@ -1,18 +1,44 @@
 const crypto = require('crypto');
 
-const encrypt = (value, passphrase, algorithm = 'aes-256-ctr') => {
-    const cipher = crypto.createCipher(algorithm, passphrase);
-    const crypted = cipher.update(value, 'utf-8', 'hex');
+const ALGORITHM = 'aes-256-ctr';
+const KEY_BYTE_LENGTH = 32;
+const IV_LENGTH = 16;
 
-    return `${algorithm}:${crypted + cipher.final('hex')}`;
+const checkKeyLength = (key) => {
+    if (!Buffer.isBuffer(key) || key.length !== KEY_BYTE_LENGTH) {
+        throw new Error(`The "key" parameter should be a ${KEY_BYTE_LENGTH} bytes Buffer`);
+    }
 };
 
-const decrypt = (entry, passphrase) => {
-    const [algorithm, value] = entry.split(':');
-    const decipher = crypto.createDecipher(algorithm, passphrase);
-    const decrypted = decipher.update(value, 'hex', 'utf-8');
+const encrypt = (value, key) => {
+    checkKeyLength(key);
 
-    return decrypted + decipher.final('utf-8');
+    const iv = crypto.randomBytes(IV_LENGTH);
+    const cipher = crypto.createCipheriv(ALGORITHM, key, iv);
+    const cipherText = cipher.update(value, 'utf-8', 'hex') + cipher.final('hex');
+
+    return `${ALGORITHM}:${iv.toString('hex')}:${cipherText}`;
 };
 
-module.exports = { encrypt, decrypt };
+const decrypt = (entry, key) => {
+    checkKeyLength(key);
+
+    const [algorithm, hexIV, value] = entry.split(':');
+
+    if (algorithm !== ALGORITHM) {
+        throw new Error(`Unsupported algorithm: ${algorithm}`);
+    }
+
+    const iv = new Buffer(hexIV, 'hex');
+    const decipher = crypto.createDecipheriv(ALGORITHM, key, iv);
+
+    return decipher.update(value, 'hex', 'utf-8') + decipher.final('utf-8');
+};
+
+module.exports = {
+    ALGORITHM,
+    IV_LENGTH,
+    KEY_BYTE_LENGTH,
+    encrypt,
+    decrypt,
+};

--- a/cli/src/crypto.js
+++ b/cli/src/crypto.js
@@ -7,30 +7,34 @@ const IV_LENGTH = 16;
 const hexToBuffer = hex => new Buffer(hex, 'hex');
 const bufferToHex = buffer => buffer.toString('hex');
 
-const bufferize = (key, tryToCast = true) => {
-    if (!Buffer.isBuffer(key) || key.length !== KEY_BYTE_LENGTH) {
-        if (tryToCast) {
-            return bufferize(hexToBuffer(key), false);
+const castKeyToBuffer = (key, castToBuffer = true) => {
+    if (Buffer.isBuffer(key)) {
+        if (key.length === KEY_BYTE_LENGTH) {
+            return key;
         }
 
-        throw new Error(`The "key" parameter should be a ${KEY_BYTE_LENGTH} bytes Buffer`);
+        throw new Error(`The "key" argument must be a ${KEY_BYTE_LENGTH} bytes Buffer`);
     }
 
-    return key;
+    if (castToBuffer) {
+        return castKeyToBuffer(hexToBuffer(key), false);
+    }
+
+    throw new Error('The "key" argument is must be a Buffer or a hexadecimal-encoded string');
 };
 
 const encrypt = (value, hexKey) => {
-    const key = bufferize(hexKey);
+    const key = castKeyToBuffer(hexKey);
     const iv = crypto.randomBytes(IV_LENGTH);
 
     const cipher = crypto.createCipheriv(ALGORITHM, key, iv);
-    const cipherText = cipher.update(value, 'utf-8', 'hex') + cipher.final('hex');
+    const cipherText = Buffer.concat([cipher.update(value, 'utf-8'), cipher.final()]);
 
-    return `${ALGORITHM}:${iv.toString('hex')}:${cipherText}`;
+    return `${ALGORITHM}:${iv.toString('hex')}:${cipherText.toString('hex')}`;
 };
 
 const decrypt = (entry, hexKey) => {
-    const key = bufferize(hexKey);
+    const key = castKeyToBuffer(hexKey);
 
     const [algorithm, hexIV, value] = entry.split(':');
 
@@ -40,8 +44,9 @@ const decrypt = (entry, hexKey) => {
 
     const iv = hexToBuffer(hexIV);
     const decipher = crypto.createDecipheriv(ALGORITHM, key, iv);
+    const decipherText = Buffer.concat([decipher.update(value, 'hex'), decipher.final()]);
 
-    return decipher.update(value, 'hex', 'utf-8') + decipher.final('utf-8');
+    return decipherText.toString('utf-8');
 };
 
 const generateNewPrivateKey = () => bufferToHex(crypto.randomBytes(KEY_BYTE_LENGTH));

--- a/cli/src/crypto.js
+++ b/cli/src/crypto.js
@@ -4,24 +4,33 @@ const ALGORITHM = 'aes-256-ctr';
 const KEY_BYTE_LENGTH = 32;
 const IV_LENGTH = 16;
 
-const checkKeyLength = (key) => {
+const hexToBuffer = hex => new Buffer(hex, 'hex');
+const bufferToHex = buffer => buffer.toString('hex');
+
+const bufferize = (key, tryToCast = true) => {
     if (!Buffer.isBuffer(key) || key.length !== KEY_BYTE_LENGTH) {
+        if (tryToCast) {
+            return bufferize(hexToBuffer(key), false);
+        }
+
         throw new Error(`The "key" parameter should be a ${KEY_BYTE_LENGTH} bytes Buffer`);
     }
+
+    return key;
 };
 
-const encrypt = (value, key) => {
-    checkKeyLength(key);
-
+const encrypt = (value, hexKey) => {
+    const key = bufferize(hexKey);
     const iv = crypto.randomBytes(IV_LENGTH);
+
     const cipher = crypto.createCipheriv(ALGORITHM, key, iv);
     const cipherText = cipher.update(value, 'utf-8', 'hex') + cipher.final('hex');
 
     return `${ALGORITHM}:${iv.toString('hex')}:${cipherText}`;
 };
 
-const decrypt = (entry, key) => {
-    checkKeyLength(key);
+const decrypt = (entry, hexKey) => {
+    const key = bufferize(hexKey);
 
     const [algorithm, hexIV, value] = entry.split(':');
 
@@ -29,11 +38,13 @@ const decrypt = (entry, key) => {
         throw new Error(`Unsupported algorithm: ${algorithm}`);
     }
 
-    const iv = new Buffer(hexIV, 'hex');
+    const iv = hexToBuffer(hexIV);
     const decipher = crypto.createDecipheriv(ALGORITHM, key, iv);
 
     return decipher.update(value, 'hex', 'utf-8') + decipher.final('utf-8');
 };
+
+const generateNewPrivateKey = () => bufferToHex(crypto.randomBytes(KEY_BYTE_LENGTH));
 
 module.exports = {
     ALGORITHM,
@@ -41,4 +52,5 @@ module.exports = {
     KEY_BYTE_LENGTH,
     encrypt,
     decrypt,
+    generateNewPrivateKey,
 };

--- a/cli/src/crypto.spec.js
+++ b/cli/src/crypto.spec.js
@@ -1,12 +1,12 @@
 const expect = require('expect');
-const { encrypt, decrypt } = require('./crypto');
+const crypto = require('crypto');
+const { encrypt, decrypt, KEY_BYTE_LENGTH } = require('./crypto');
 
 describe('Crypto Features', () => {
     it('should keep the consistancy between encryption & decryption', () => {
         const data = 'SOME VERY PRIVATE INFO';
-        const passphrase = 'passphrase';
-        const algo = 'aes-256-ctr';
-        const encryptedData = encrypt(data, passphrase, algo);
+        const passphrase = crypto.randomBytes(KEY_BYTE_LENGTH);
+        const encryptedData = encrypt(data, passphrase);
 
         expect(encryptedData).toNotBe(data);
 
@@ -17,11 +17,10 @@ describe('Crypto Features', () => {
 
     it('should not return the identic signature twice for the same given entry and passphrase', () => {
         const data = 'SOME VERY PRIVATE INFO';
-        const passphrase = 'passphrase';
-        const algo = 'aes-256-ctr';
+        const passphrase = crypto.randomBytes(KEY_BYTE_LENGTH);
 
-        const encryptedData = encrypt(data, passphrase, algo);
-        const encryptedData2 = encrypt(data, passphrase, algo);
+        const encryptedData = encrypt(data, passphrase);
+        const encryptedData2 = encrypt(data, passphrase);
 
         expect(encryptedData).toNotBe(encryptedData2);
 

--- a/cli/src/crypto.spec.js
+++ b/cli/src/crypto.spec.js
@@ -1,11 +1,10 @@
 const expect = require('expect');
-const crypto = require('crypto');
-const { encrypt, decrypt, KEY_BYTE_LENGTH } = require('./crypto');
+const { encrypt, decrypt, generateNewPrivateKey } = require('./crypto');
 
 describe('Crypto Features', () => {
     it('should keep the consistancy between encryption & decryption', () => {
         const data = 'SOME VERY PRIVATE INFO';
-        const privateKey = crypto.randomBytes(KEY_BYTE_LENGTH);
+        const privateKey = generateNewPrivateKey();
         const encryptedData = encrypt(data, privateKey);
 
         expect(encryptedData).toNotBe(data);
@@ -17,7 +16,7 @@ describe('Crypto Features', () => {
 
     it('should not return the identic signature twice for the same given entry and private key', () => {
         const data = 'SOME VERY PRIVATE INFO';
-        const privateKey = crypto.randomBytes(KEY_BYTE_LENGTH);
+        const privateKey = generateNewPrivateKey();
 
         const encryptedData = encrypt(data, privateKey);
         const encryptedData2 = encrypt(data, privateKey);

--- a/cli/src/crypto.spec.js
+++ b/cli/src/crypto.spec.js
@@ -14,4 +14,21 @@ describe('Crypto Features', () => {
 
         expect(decryptedData).toBe(data);
     });
+
+    it('should not return the identic signature twice for the same given entry and passphrase', () => {
+        const data = 'SOME VERY PRIVATE INFO';
+        const passphrase = 'passphrase';
+        const algo = 'aes-256-ctr';
+
+        const encryptedData = encrypt(data, passphrase, algo);
+        const encryptedData2 = encrypt(data, passphrase, algo);
+
+        expect(encryptedData).toNotBe(encryptedData2);
+
+        const decryptedData = decrypt(encryptedData, passphrase);
+        const decryptedData2 = decrypt(encryptedData2, passphrase);
+
+        expect(decryptedData).toBe(data);
+        expect(decryptedData2).toBe(data);
+    });
 });

--- a/cli/src/crypto.spec.js
+++ b/cli/src/crypto.spec.js
@@ -5,27 +5,27 @@ const { encrypt, decrypt, KEY_BYTE_LENGTH } = require('./crypto');
 describe('Crypto Features', () => {
     it('should keep the consistancy between encryption & decryption', () => {
         const data = 'SOME VERY PRIVATE INFO';
-        const passphrase = crypto.randomBytes(KEY_BYTE_LENGTH);
-        const encryptedData = encrypt(data, passphrase);
+        const privateKey = crypto.randomBytes(KEY_BYTE_LENGTH);
+        const encryptedData = encrypt(data, privateKey);
 
         expect(encryptedData).toNotBe(data);
 
-        const decryptedData = decrypt(encryptedData, passphrase);
+        const decryptedData = decrypt(encryptedData, privateKey);
 
         expect(decryptedData).toBe(data);
     });
 
-    it('should not return the identic signature twice for the same given entry and passphrase', () => {
+    it('should not return the identic signature twice for the same given entry and private key', () => {
         const data = 'SOME VERY PRIVATE INFO';
-        const passphrase = crypto.randomBytes(KEY_BYTE_LENGTH);
+        const privateKey = crypto.randomBytes(KEY_BYTE_LENGTH);
 
-        const encryptedData = encrypt(data, passphrase);
-        const encryptedData2 = encrypt(data, passphrase);
+        const encryptedData = encrypt(data, privateKey);
+        const encryptedData2 = encrypt(data, privateKey);
 
         expect(encryptedData).toNotBe(encryptedData2);
 
-        const decryptedData = decrypt(encryptedData, passphrase);
-        const decryptedData2 = decrypt(encryptedData2, passphrase);
+        const decryptedData = decrypt(encryptedData, privateKey);
+        const decryptedData2 = decrypt(encryptedData2, privateKey);
 
         expect(decryptedData).toBe(data);
         expect(decryptedData2).toBe(data);

--- a/cli/src/domain/config.js
+++ b/cli/src/domain/config.js
@@ -31,7 +31,7 @@ module.exports = (client, ui) => {
 
             body[key] = isNullValue(value)
                 ? null // Do not encrypt null values
-                : encrypt(value.toString(), project.passphrase);
+                : encrypt(value.toString(), project.privateKey);
         });
 
         const url = `${project.origin}/projects/${project.id}/environments/${env}/configurations/${configName}/${tag}`;
@@ -67,7 +67,7 @@ module.exports = (client, ui) => {
             const value = body[key];
 
             if (!isNullValue(value)) {
-                body[key] = decrypt(value.toString(), project.passphrase);
+                body[key] = decrypt(value.toString(), project.privateKey);
             }
         });
 

--- a/cli/src/domain/project.js
+++ b/cli/src/domain/project.js
@@ -2,6 +2,7 @@ const fs = require('fs');
 const ini = require('ini');
 const path = require('path');
 const { CONFIG_FOLDER, CONFIG_PATH, DEFAULT_ORIGIN } = require('./constants');
+const { generateNewPrivateKey } = require('../crypto');
 
 module.exports = (client, ui) => {
     const create = function* (name, environment, origin = DEFAULT_ORIGIN) {
@@ -15,13 +16,13 @@ module.exports = (client, ui) => {
         }
     };
 
-    const saveToConfig = function* (project, passphrase, origin = DEFAULT_ORIGIN) {
+    const saveToConfig = function* (project, privateKey, origin = DEFAULT_ORIGIN) {
         const config = ini.stringify({
             projectId: project.id,
             accessKey: project.accessKey,
             secretToken: project.writeToken,
             origin,
-            passphrase,
+            privateKey,
         }, { section: 'project' });
 
         const filename = `${process.cwd()}${path.sep}${CONFIG_PATH}`;
@@ -29,7 +30,7 @@ module.exports = (client, ui) => {
         yield cb => fs.writeFile(filename, config, { flag: 'w' }, cb);
     };
 
-    const checkProjectInfos = ({ id, accessKey, secretToken, passphrase, origin }) => {
+    const checkProjectInfos = ({ id, accessKey, secretToken, privateKey, origin }) => {
         const errors = [];
         const { red, dim, bold } = ui.colors;
 
@@ -50,9 +51,9 @@ ${set('COMFY_ACCESS_KEY')}`);
 ${set('COMFY_SECRET_TOKEN')}`);
         }
 
-        if (!passphrase) {
-            errors.push(`Unable to locate the ${red('passphrase')} to decrypt your configs.
-${set('COMFY_PASSPHRASE')}`);
+        if (!privateKey) {
+            errors.push(`Unable to locate the ${red('private key')} to decrypt your configs.
+${set('COMFY_PRIVATE_KEY')}`);
         }
 
         if (!origin) {
@@ -74,7 +75,7 @@ Type ${bold('comfy init')} to do so.`);
             id: process.env.COMFY_PROJECT_ID,
             accessKey: process.env.COMFY_ACCESS_KEY,
             secretToken: process.env.COMFY_SECRET_TOKEN,
-            passphrase: process.env.COMFY_PASSPHRASE,
+            privateKey: process.env.COMFY_PRIVATE_KEY,
             origin: process.env.COMFY_ORIGIN,
         };
 
@@ -91,7 +92,7 @@ Type ${bold('comfy init')} to do so.`);
             id: config.project.projectId,
             accessKey: config.project.accessKey,
             secretToken: config.project.secretToken,
-            passphrase: config.project.passphrase,
+            privateKey: config.project.privateKey,
             origin: config.project.origin,
         });
 
@@ -105,5 +106,6 @@ Type ${bold('comfy init')} to do so.`);
         saveToConfig,
         CONFIG_FOLDER,
         CONFIG_PATH,
+        generateNewPrivateKey,
     };
 };

--- a/test/specs/init.js
+++ b/test/specs/init.js
@@ -44,10 +44,10 @@ describe('Project initialization', () => {
         expect(stdout).toInclude('secretToken=');
     });
 
-    it('should create passphrase', function* () {
+    it('should create private key', function* () {
         yield run("comfy init --origin 'http://localhost:3000'");
 
         const { stdout } = yield run('cat .comfy/config');
-        expect(stdout).toInclude('passphrase=');
+        expect(stdout).toInclude('privateKey=');
     });
 });


### PR DESCRIPTION
Part of #33 

### Rationale

Use the best encryption available: AES 256 (`aes-256-ctr`) with IV, HMAC-SHA256 signed.
The signature could be make in another PR.

### Backward Comptibility Break
We now use the AES-256 algorithm with an Initialization Vector (IV). This is far more secure since the same data will not generate the same encrypted output.

```js
encrypt('data') === encrypt('data') // false
```

The drawback is that where we used a passphrase before, we now have to use a **32 bytes private key**.
This key MUST be generated randomly and not asked to the user. Preferably, this key must not be stored in plain text.
So, the real role of the passphrase is to decrypt the private key from the `.comfy/config` file (this will be the goal of another PR).

## TODO
- [x] Write a test to forbbid identic output for the same couple entry-passphrase
- [x] Implement the new randomized crypto function